### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/stefreak/nut/security/code-scanning/1](https://github.com/stefreak/nut/security/code-scanning/1)

To fix this problem, explicitly specify the `permissions` key for the workflow or individual job, restricting the GITHUB_TOKEN used by the workflow to the minimum necessary permissions. In this case, only read access to repository contents is required for the test pipeline, so the best fix is to add a `permissions: contents: read` block at the top level of the workflow. This guarantees that unless overridden on specific jobs, all jobs—including `test`—will only have read-level access to the repository. Add the following block immediately after the `name:` field, before the `on:` key (suggested by GitHub documentation and best practice), with proper YAML indentation and structure. No imports, methods, or additional definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
